### PR TITLE
Fix README incorrect use statement

### DIFF
--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -23,7 +23,7 @@ $capsule->addConnection([
 ]);
 
 // Set the event dispatcher used by Eloquent models... (optional)
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Container\Container;
 $capsule->setEventDispatcher(new Dispatcher(new Container));
 


### PR DESCRIPTION
Fix incorrect using in bootstrap documentation: Illuminate\Events\Dispatcher > Illuminate\Contracts\Events\Dispatcher

![error](https://user-images.githubusercontent.com/1455401/172068747-1d6d5e10-37e4-436e-9a4f-d350ff898ee7.png)

